### PR TITLE
Support for pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ pulls:
       Please add an `area:<team>` label to this pull request.
 ```
 
+### Backwards compatibility
+Previous version of the bot will still work with current version, as the schema for the configuration file does not change the structure. So it's possible to upgrade and keep old configuration:
+
+```yaml
+# The old format matches the new one, using a different name
+comments:
+  - label: needs-area
+    comment: |
+      Please add an `area:<team>` label to this issue.
+```
+
 ## Contribute
 
 If you have suggestions for how this bot could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Downloads][npm-downloads]][npm-url] [![version][npm-version]][npm-url]
 [![Build Status][travis-status]][travis-url]
 
-A [Probot](https://probot.github.io) bot to add/remove a comment to issues when a label is present/removed.
+A [Probot](https://probot.github.io) bot to add/remove a comment to issues and pull requests when a label is present/removed.
 
 ## Setup
 
@@ -14,12 +14,16 @@ If the config is empty or doesn't exist, the bot will not run.
 ```yml
 # Example Config
 
-# This config will look for any issues that have been labeled with `needs-area`. A comment
-# will be added to the issue and will be removed once the `needs-area` label is removed.
-comments:
+# This config will look for any issues and pull requests that have been labeled with `needs-area`. A comment
+# will be added to the issue or pull request and will be removed once the `needs-area` label is removed.
+issues:
   - label: needs-area
     comment: |
       Please add an `area:<team>` label to this issue.
+pulls:
+  - label: needs-area
+    comment: |
+      Please add an `area:<team>` label to this pull request.
 ```
 
 ## Contribute

--- a/src/__test__/fakecontext.ts
+++ b/src/__test__/fakecontext.ts
@@ -16,7 +16,7 @@ export class FakeContext extends Context<any> {
     this.payload = payload;
     this.github = github;
     this.config = configMethod;
-    this.name = "test";
+    this.name = github.event;
     this.id = "test";
     this.log = {
       child: (x: any) => {

--- a/src/__test__/fakegithub.ts
+++ b/src/__test__/fakegithub.ts
@@ -4,12 +4,16 @@ export class FakeGithub {
   public comments: string[];
   public commentsAdded: string[];
   public commentsRemoved: string[];
+  public event: string;
   public issues: FakeIssueApi;
+  public pullRequests: FakeIssueApi;
 
-  constructor(comments: string[]) {
+  constructor(comments: string[], event: string = "issues") {
     this.comments = comments;
     this.commentsAdded = [];
     this.commentsRemoved = [];
+    this.event = event;
     this.issues = new FakeIssueApi(this);
+    this.pullRequests = new FakeIssueApi(this); // comments in a PR are related to the underlying issue
   }
 }

--- a/src/__test__/handler.pull_request.test.ts
+++ b/src/__test__/handler.pull_request.test.ts
@@ -1,0 +1,89 @@
+import { handle } from "../handler";
+import { IComment } from "../models";
+import { FakeContext } from "./fakecontext";
+import { FakeGithub } from "./fakegithub";
+
+it("adds a comment when the label has been added to the pull request", () => {
+  expect.assertions(2);
+  const github = new FakeGithub([], "pull_request");
+  const context = new FakeContext(
+    { label: { name: "test" }, action: "labeled" },
+    github,
+    {}
+  );
+  const commentBody = "this is a test comment";
+  const comments: IComment[] = [{ label: "test", comment: commentBody }];
+
+  return handle(context, comments).then(resp => {
+    expect(github.commentsAdded).toEqual([commentBody]);
+    expect(github.comments).toEqual([commentBody]);
+  });
+});
+
+it("doesnt add a comment when the label doesn't match", () => {
+  expect.assertions(2);
+  const github = new FakeGithub([], "pull_request");
+  const context = new FakeContext(
+    { label: { name: "this" }, action: "labeled" },
+    github,
+    {}
+  );
+  const commentBody = "this is a test comment";
+  const comments: IComment[] = [{ label: "test", comment: commentBody }];
+
+  return handle(context, comments).then(resp => {
+    expect(github.commentsAdded).toEqual([]);
+    expect(github.comments).toEqual([]);
+  });
+});
+
+it("doesn't add a comment when the comment already exists on the pull request", () => {
+  expect.assertions(2);
+  const commentBody = "this is a test comment";
+  const github = new FakeGithub([commentBody, "new comment"], "pull_request");
+  const context = new FakeContext(
+    { label: { name: "this" }, action: "labeled" },
+    github,
+    {}
+  );
+  const comments: IComment[] = [{ label: "this", comment: commentBody }];
+
+  return handle(context, comments).then(resp => {
+    expect(github.commentsAdded).toEqual([]);
+    expect(github.comments).toEqual([commentBody, "new comment"]);
+  });
+});
+
+it("removes a comment when the label is removed", () => {
+  expect.assertions(2);
+  const commentBody = "this is a test comment";
+  const github = new FakeGithub([commentBody], "pull_request");
+  const context = new FakeContext(
+    { label: { name: "test" }, action: "unlabeled" },
+    github,
+    {}
+  );
+  const comments: IComment[] = [{ label: "test", comment: commentBody }];
+
+  return handle(context, comments).then(resp => {
+    expect(github.commentsAdded).toEqual([]);
+    expect(github.commentsRemoved).toEqual([commentBody]);
+  });
+});
+
+it("doesn't remove a comment when the label doesn't match", () => {
+  expect.assertions(2);
+  const commentBody = "this is a test comment";
+  const github = new FakeGithub([commentBody], "pull_request");
+  const context = new FakeContext(
+    { label: { name: "this" }, action: "unlabeled" },
+    github,
+    {}
+  );
+  const comments: IComment[] = [{ label: "test", comment: commentBody }];
+
+  return handle(context, comments).then(resp => {
+    expect(github.commentsAdded).toEqual([]);
+    expect(github.commentsRemoved).toEqual([]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ import { handle } from "./handler";
 import { IConfig, schema } from "./models";
 
 module.exports = async (app: Application) => {
-  const events = ["issues.labeled", "issues.unlabeled"];
+  const events = [
+    "issues.labeled",
+    "issues.unlabeled",
+    "pull_request.labeled",
+    "pull_request.unlabeled"
+  ];
   const configManager = new ConfigManager<IConfig>("comment.yml", {}, schema);
 
   app.log.info("probot-add-comment loaded");
@@ -24,10 +29,16 @@ module.exports = async (app: Application) => {
       context.log.error(err);
       return {} as IConfig;
     });
-    if (config.comments) {
+
+    let eventType = config.issues;
+    if ("pull_request" === context.event) {
+      eventType = config.pulls;
+    }
+
+    if (eventType) {
       logger.debug("Config exists");
       logger.debug(config);
-      await handle(context, config.comments!).catch(err => {
+      await handle(context, eventType!).catch(err => {
         context.log.error(err);
       });
       logger.debug("Handled");

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@ module.exports = async (app: Application) => {
     if ("pull_request" === context.event) {
       eventType = config.pulls;
     }
+    if (!eventType) {
+      eventType = config.comments;
+    }
 
     if (eventType) {
       logger.debug("Config exists");

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,6 +6,7 @@ export interface IComment {
 }
 
 export interface IConfig {
+  comments?: IComment[];
   issues?: IComment[];
   pulls?: IComment[];
 }
@@ -22,6 +23,12 @@ export interface IConfig {
 //     There is no area label added to this issue/PR.
 //     Please add an area:<team> label
 export const schema = Joi.object().keys({
+  comments: Joi.array().items(
+    Joi.object().keys({
+      comment: Joi.string(),
+      label: Joi.string()
+    })
+  ),
   issues: Joi.array().items(
     Joi.object().keys({
       comment: Joi.string(),

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,17 +6,29 @@ export interface IComment {
 }
 
 export interface IConfig {
-  comments?: IComment[];
+  issues?: IComment[];
+  pulls?: IComment[];
 }
 
 //
-// comments:
+// issues:
+// - label: needs-area
+//   comment: |
+//     There is no area label added to this issue/PR.
+//     Please add an area:<team> label
+// pulls:
 // - label: needs-area
 //   comment: |
 //     There is no area label added to this issue/PR.
 //     Please add an area:<team> label
 export const schema = Joi.object().keys({
-  comments: Joi.array().items(
+  issues: Joi.array().items(
+    Joi.object().keys({
+      comment: Joi.string(),
+      label: Joi.string()
+    })
+  ),
+  pulls: Joi.array().items(
     Joi.object().keys({
       comment: Joi.string(),
       label: Joi.string()


### PR DESCRIPTION
## What does this PR do?
It adds support for using this bot with pull requests too, using same configuration file as in the [`probot-labeler`](https://github.com/lswith/probot-labeler) bot:

```yaml
issues:
  - label: needs-area
    comment: |
      Please add an `area:<team>` label to this issue.
pulls:
  - label: needs-area
    comment: |
      Please add an `area:<team>` label to this pull request.
```

As this change modifies the schema of the configuration file, I'd suggest bumping the project with a major.

On the other hand, as the structure is almost the same, I'm providing a fallback for previous versions of the bot, so no need of recconfiguring it everywhere.


## Why is it important?
The functionality of this bot is great, so why not adding that behavior to PR? :)

## Related issues
- Closes #7 